### PR TITLE
Refresh ARP table and send pairing prompt.

### DIFF
--- a/lib/lg-tv-adapter.js
+++ b/lib/lg-tv-adapter.js
@@ -5,7 +5,8 @@
 
 const {Adapter} = require('gateway-addon');
 const {Client} = require('node-ssdp');
-const {getMAC} = require('arp');
+const findDevices = require('local-devices');
+const ipRegex = require('ip-regex')({exact: true});
 const LGTV = require('lgtv2');
 const LgTvDatabase = require('./lg-tv-database');
 const LgTvDevice = require('./lg-tv-device');
@@ -28,8 +29,54 @@ class LgTvAdapter extends Adapter {
     this.knownDevices = new Set();
     this.config = manifest.moziot.config;
 
-    this.addKnownDevices();
-    this.startSearch();
+    this.arpTable = {};
+
+    this.refreshArpTable().then(() => {
+      this.addKnownDevices();
+      this.startSearch();
+      this.interval = setInterval(this.refreshArpTable.bind(this), 30000);
+    });
+  }
+
+  /**
+   * Start the pairing process.
+   *
+   * For this adapter, that's always happening in the background, but we should
+   * send a pairing prompt if we can.
+   */
+  startPairing() {
+    if (this.sendPairingPrompt) {
+      this.sendPairingPrompt(
+        // eslint-disable-next-line max-len
+        'Enable LG Connect Apps and accept the pairing request on your TV when prompted.',
+        'https://github.com/mozilla-iot/lg-tv-adapter#readme'
+      );
+    }
+  }
+
+  /**
+   * Refresh the cached ARP table.
+   *
+   * @returns {Promise} Promise which resolves when the refresh completes.
+   */
+  refreshArpTable() {
+    return findDevices().then((devices) => {
+      for (const dev of devices) {
+        this.arpTable[dev.ip] = dev.mac;
+      }
+    }).catch((e) => {
+      console.warn('Error while refreshing ARP table:', e);
+    });
+  }
+
+  /**
+   * Get the MAC address for a given IP address.
+   *
+   * @param {string} addr - IP address
+   * @returns {string} MAC address
+   */
+  getMac(addr) {
+    return this.arpTable[addr] || '00:00:00:00:00:00';
   }
 
   /**
@@ -76,42 +123,30 @@ class LgTvAdapter extends Adapter {
    */
   addKnownDevices() {
     for (const addr of this.config.devices) {
-      if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+$/.test(addr)) {
+      if (!ipRegex.test(addr)) {
         continue;
       }
 
       this.knownDevices.add(addr);
 
-      getMAC(addr, (err, data) => {
-        if (err) {
-          console.error(`Failed to get MAC for ${addr}: ${data}`);
-          return;
-        }
-
-        this.loadKey(data).then((clientKey) => {
-          const client = new LGTV({
-            url: `ws://${addr}:3000`,
-            saveKey: (key, cb) => {
-              this.saveKey(data, key, cb);
-            },
-            clientKey,
-          });
-          client.on('error', (e) => {
-            console.error(`Failed to connect to device: ${e}`);
-          });
-          client.on('connect', () => {
-            const dev = new LgTvDevice(
-              this,
-              '[LG] webOS TV',
-              addr,
-              data,
-              client
-            );
-            Promise.all(dev.promises).then(() => {
-              this.handleDeviceAdded(dev);
-            }).catch((e) => {
-              console.error(`Failed to create device: ${e}`);
-            });
+      const mac = this.getMac(addr);
+      this.loadKey(mac).then((clientKey) => {
+        const client = new LGTV({
+          url: `ws://${addr}:3000`,
+          saveKey: (key, cb) => {
+            this.saveKey(mac, key, cb);
+          },
+          clientKey,
+        });
+        client.on('error', (e) => {
+          console.error(`Failed to connect to device: ${e}`);
+        });
+        client.on('connect', () => {
+          const dev = new LgTvDevice(this, '[LG] webOS TV', addr, mac, client);
+          Promise.all(dev.promises).then(() => {
+            this.handleDeviceAdded(dev);
+          }).catch((e) => {
+            console.error(`Failed to create device: ${e}`);
           });
         });
       });
@@ -136,30 +171,24 @@ class LgTvAdapter extends Adapter {
 
           this.knownDevices.add(addr);
 
-          getMAC(addr, (err, data) => {
-            if (err) {
-              console.error(`Failed to get MAC for ${addr}: ${data}`);
-              return;
-            }
-
-            this.loadKey(data).then((clientKey) => {
-              const client = new LGTV({
-                url: `ws://${addr}:3000`,
-                saveKey: (key, cb) => {
-                  this.saveKey(data, key, cb);
-                },
-                clientKey,
-              });
-              client.on('error', (e) => {
-                console.error(`Failed to connect to device: ${e}`);
-              });
-              client.on('connect', () => {
-                const dev = new LgTvDevice(this, name, addr, data, client);
-                Promise.all(dev.promises).then(() => {
-                  this.handleDeviceAdded(dev);
-                }).catch((e) => {
-                  console.error(`Failed to create device: ${e}`);
-                });
+          const mac = this.getMac(addr);
+          this.loadKey(mac).then((clientKey) => {
+            const client = new LGTV({
+              url: `ws://${addr}:3000`,
+              saveKey: (key, cb) => {
+                this.saveKey(mac, key, cb);
+              },
+              clientKey,
+            });
+            client.on('error', (e) => {
+              console.error(`Failed to connect to device: ${e}`);
+            });
+            client.on('connect', () => {
+              const dev = new LgTvDevice(this, name, addr, mac, client);
+              Promise.all(dev.promises).then(() => {
+                this.handleDeviceAdded(dev);
+              }).catch((e) => {
+                console.error(`Failed to create device: ${e}`);
               });
             });
           });
@@ -182,6 +211,18 @@ class LgTvAdapter extends Adapter {
     }
 
     return Promise.resolve(device);
+  }
+
+  /**
+   * Clean up before shutting down.
+   */
+  unload() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      delete this.interval;
+    }
+
+    return super.unload();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lg-tv-adapter",
   "display_name": "LG webOS TV",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "LG webOS TV adapter for Mozilla IoT Gateway",
   "main": "index.js",
   "scripts": {
@@ -26,12 +26,14 @@
   },
   "homepage": "https://github.com/mozilla-iot/lg-tv-adapter#readme",
   "dependencies": {
-    "arp": "0.0.3",
+    "ip-regex": "^4.0.0",
     "lgtv2": "^1.4.1",
+    "local-devices": "2.0.0",
     "node-ssdp": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": "^5.12.1"
+    "babel-eslint": "^10.0.1",
+    "eslint": "^5.15.3"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
If the ARP table was empty, the adapter could fail to pair with
devices properly.