### PR TITLE
Remove specific name match when searching for new devices.

### DIFF
--- a/lib/lg-tv-adapter.js
+++ b/lib/lg-tv-adapter.js
@@ -161,38 +161,36 @@ class LgTvAdapter extends Adapter {
     ssdpClient.on('response', (headers) => {
       if (headers.hasOwnProperty('DLNADEVICENAME.LGE.COM')) {
         const name = decodeURIComponent(headers['DLNADEVICENAME.LGE.COM']);
-        if (name.startsWith('[LG] webOS TV')) {
-          const url = new URL(headers.LOCATION);
-          const addr = url.hostname;
+        const url = new URL(headers.LOCATION);
+        const addr = url.hostname;
 
-          if (this.knownDevices.has(addr)) {
-            return;
-          }
+        if (this.knownDevices.has(addr)) {
+          return;
+        }
 
-          this.knownDevices.add(addr);
+        this.knownDevices.add(addr);
 
-          const mac = this.getMac(addr);
-          this.loadKey(mac).then((clientKey) => {
-            const client = new LGTV({
-              url: `ws://${addr}:3000`,
-              saveKey: (key, cb) => {
-                this.saveKey(mac, key, cb);
-              },
-              clientKey,
-            });
-            client.on('error', (e) => {
-              console.error(`Failed to connect to device: ${e}`);
-            });
-            client.on('connect', () => {
-              const dev = new LgTvDevice(this, name, addr, mac, client);
-              Promise.all(dev.promises).then(() => {
-                this.handleDeviceAdded(dev);
-              }).catch((e) => {
-                console.error(`Failed to create device: ${e}`);
-              });
+        const mac = this.getMac(addr);
+        this.loadKey(mac).then((clientKey) => {
+          const client = new LGTV({
+            url: `ws://${addr}:3000`,
+            saveKey: (key, cb) => {
+              this.saveKey(mac, key, cb);
+            },
+            clientKey,
+          });
+          client.on('error', (e) => {
+            console.error(`Failed to connect to device: ${e}`);
+          });
+          client.on('connect', () => {
+            const dev = new LgTvDevice(this, name, addr, mac, client);
+            Promise.all(dev.promises).then(() => {
+              this.handleDeviceAdded(dev);
+            }).catch((e) => {
+              console.error(`Failed to create device: ${e}`);
             });
           });
-        }
+        });
       }
     });
     ssdpClient.search('urn:schemas-upnp-org:device:MediaRenderer:1');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lg-tv-adapter",
   "display_name": "LG webOS TV",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "LG webOS TV adapter for Mozilla WebThings Gateway",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Resolved a problem with new device search which prevented the adapter from finding new TVs.  The adapter specifically was looking for SSDP headers where the field "DLNADEVICENAME.LGE.COM" started with "[LG] webOS TV".  Any TV which did not match was ignored.  This becomes a problem when users rename their TV through the webOS Network Settings.