### PR TITLE
Fiter SSDP Service Type before adding LG TV device

### DIFF
--- a/lib/lg-tv-adapter.js
+++ b/lib/lg-tv-adapter.js
@@ -123,9 +123,11 @@ class LgTvAdapter extends Adapter {
   setupSsdpClient() {
     this.ssdpClient = new Client();
     this.ssdpClient.on('response', (headers) => {
-      const url = new URL(headers.LOCATION);
-      const addr = url.hostname;
-      this.addDevice(addr);
+      if (headers.ST === SSDP_SERVICE) {
+        const url = new URL(headers.LOCATION);
+        const addr = url.hostname;
+        this.addDevice(addr);
+      }
     });
   }
 


### PR DESCRIPTION
It was noticed on my home network that the number of devices returned by the SSDP client included those that didn't match the service type being filtered. This resulted in the lg-tv-adapter probing my Philips hue device on port 3000 unnecessarily.

This PR caters for this by filtering devices that do not have the relevant LG TV service type. Thereby reducing false positives.

It maybe that the code ```this.ssdpClient.search(SSDP_SERVICE);``` is ineffective.